### PR TITLE
Load genomeDB only .onAttach

### DIFF
--- a/ribiosAnnotation/R/utils.R
+++ b/ribiosAnnotation/R/utils.R
@@ -25,6 +25,7 @@ ORACLE.HOME <- "/opt/oracle/client/10/run_1"
 ## maximum vector length in the IN syntax
 #' @export ORACLE.IN.NMAX
 ORACLE.IN.NMAX <- 1000L
+.conEnv = new.env()
 
 
 ## function to test whether Oracle is available
@@ -53,14 +54,21 @@ hasOracle <- function() {
   } else {
     ## require(RJDBC)
   }
+  con = ribiosCon(db="bin", user=ORACLE.BIN.USER, password=ORACLE.BIN.PWD)
+  assign("ORACLE.BIN.CON", con, envir=.conEnv)
 }
 
 ## automatically establish a connection, depending on whether Oracle client is installed
 #' @export ribiosCon
 ribiosCon <- function(db="bia", user="biread", password="biread", forceJDBC=FALSE) {
-  if(hasOracle() & !forceJDBC) {
+  if(db == "bin" && exists("ORACLE.BIN.CON", envir=.conEnv)) {
+      print(sprintf("Using estabilshed database connection to %s", db))
+      return(get("ORACLE.BIN.CON", envir=.conEnv))
+  } else if(hasOracle() & !forceJDBC) {
+    print(sprintf("Estabilshing ROracle connection to %s", db))
     con <- dbConnect(ORA, user = user, password = password, db = db)
   } else {
+    print(sprintf("Estabilshin RJDBC connection to %s", db))
     options(java.parameters = "-Xmx4g" ) ## increase the heap size before the RJDBC package is loaded
     suppressWarnings(suppressMessages(hasJDBC <- requireNamespace("RJDBC")))
     if(!hasJDBC)


### PR DESCRIPTION
Running ribiosAnnotaion in batch jobs caused the database server to
collapse due to the vast ammount of connections that were created.
This commit solves that issue by estabilishing a connection only
once and cacheing it for later usage .